### PR TITLE
Remove inputs and simplify interface

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,54 @@
+# furyagent module version unreleased
+
+Welcome to this new Fury module. This time, this repository serves as the new home for [`furyagent`] related software.
+Here you can find resources like `terraform` modules, `ansible` roles, and many more.
+All related to the [`furyagent`] tool.
+
+## Changelog
+
+- Move roles from [fury-kubernetes-aws](https://github.com/sighupio/fury-kubernetes-aws) repository to this repository.
+- Simplify the terraform module interface
+
+## Upgrade path
+
+### Use new roles
+
+First, replace any previous references from `fury-kubernetes-aws` to this new one: `fury-kubernetes-furyagent`. Then:
+
+```bash
+$ furyctl vendor
+# And maybe
+$ furyagent <command>
+```
+
+[`furyagent`]: https://github.com/sighupio/furyagent
+
+### Change the interface of terraform modules 
+
+Old interface: 
+
+```hcl
+module "s3-furyagent" {
+    source                  = "path/to/this/s3-furyagent"
+    furyagent_bucket_name   = "sighup-backup"
+    cluster_name            = "sighup"
+    environment             = "production"
+    aws_region              = "eu-west-1"
+}
+```
+
+New interface:
+
+```hcl
+module "s3-furyagent" {
+  source                  = "path/to/this/s3-furyagent"
+  furyagent_bucket_name   = "sighup-backup"
+  tags                    = {
+      "cluster" : "sighup",
+      "env"     : "production",
+      "any-key" : "any-value"
+  }
+}
+```
+
+

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -23,9 +23,9 @@ $ furyagent <command>
 
 [`furyagent`]: https://github.com/sighupio/furyagent
 
-### Change the interface of terraform modules 
+### Change the interface of terraform modules
 
-Old interface: 
+Old interface:
 
 ```hcl
 module "s3-furyagent" {

--- a/modules/s3-furyagent/README.md
+++ b/modules/s3-furyagent/README.md
@@ -11,12 +11,10 @@ and to be provisioned.
 
 ## Inputs
 
-| Name                  | Description                                   | Type     | Default       | Required |
-| --------------------- | --------------------------------------------- | -------- | ------------- | :------: |
-| cluster_name          | Name of the cluster                           | `string` | n/a           |   yes    |
-| environment           | Name of the environment. Example: development | `string` | n/a           |   yes    |
-| furyagent_bucket_name | Name of the bucket to create                  | `string` | n/a           |   yes    |
-| aws_region            | Region where to create the bucket             | `string` | `"eu-west-1"` |    no    |
+| Name                  | Description                                   | Type         | Default       | Required |
+| --------------------- | --------------------------------------------- | ------------ | ------------- | :------: |
+| furyagent_bucket_name | Name of the bucket to create                  | `string`     | n/a           |   yes    |
+| tags                  | Custom tags to apply to resources             | `map(string)`| `{}`          |    no    |
 
 ## Outputs
 
@@ -28,13 +26,16 @@ and to be provisioned.
 | furyagent_ansible_secrets | Ansible variable file containing AWS credentials and bucket name |
 
 ## Usage
+
 ```hcl
 module "s3-furyagent" {
-    source                  = "../vendor/modules/s3-furyagent"
-    cluster_name            = "sighup"
-    environment             = "production"
-    aws_region              = "eu-west-1"
-    furyagent_bucket_name   = "sighup-backup"
+  source                  = "path/to/this/s3-furyagent"
+  furyagent_bucket_name   = "sighup-backup"
+  tags                    = {
+      "cluster" : "sighup",
+      "env"     : "production",
+      "any-key" : "any-value"
+  }
 }
 ```
 

--- a/modules/s3-furyagent/input.tf
+++ b/modules/s3-furyagent/input.tf
@@ -4,20 +4,12 @@
  * license that can be found in the LICENSE file.
  */
 
-variable aws_region {
-  type        = string
-  description = "Region where to create the bucket"
-  default     = "eu-west-1"
-}
-variable cluster_name {
-  type        = string
-  description = "Name of the cluster"
-}
-variable environment {
-  type        = string
-  description = "Name of the environment. Example: development"
-}
-variable furyagent_bucket_name {
+variable "furyagent_bucket_name" {
   type        = string
   description = "Name of the bucket to create"
+}
+variable "tags" {
+  type        = map(string)
+  description = "Custom tags to apply to resources"
+  default     = {}
 }

--- a/modules/s3-furyagent/input.tf
+++ b/modules/s3-furyagent/input.tf
@@ -8,6 +8,7 @@ variable "furyagent_bucket_name" {
   type        = string
   description = "Name of the bucket to create"
 }
+
 variable "tags" {
   type        = map(string)
   description = "Custom tags to apply to resources"

--- a/modules/s3-furyagent/output.tf
+++ b/modules/s3-furyagent/output.tf
@@ -10,7 +10,7 @@ locals {
 
 aws_access_key: "${aws_iam_access_key.main.id}"
 aws_secret_key: "${aws_iam_access_key.main.secret}"
-aws_region: "${var.aws_region}"
+aws_region: "${aws_s3_bucket.main.region}"
 s3_bucket_name: "${var.furyagent_bucket_name}"
 EOF
 }

--- a/modules/s3-furyagent/s3.tf
+++ b/modules/s3-furyagent/s3.tf
@@ -41,4 +41,5 @@ resource "aws_s3_bucket" "main" {
     {
       Name = var.furyagent_bucket_name
     }
+  )
 }

--- a/modules/s3-furyagent/s3.tf
+++ b/modules/s3-furyagent/s3.tf
@@ -36,9 +36,5 @@ resource "aws_s3_bucket" "main" {
     }
   }
 
-  tags = {
-    Name        = var.furyagent_bucket_name
-    Cluster     = var.cluster_name
-    Environment = var.environment
-  }
+  tags = var.tags
 }

--- a/modules/s3-furyagent/s3.tf
+++ b/modules/s3-furyagent/s3.tf
@@ -36,5 +36,9 @@ resource "aws_s3_bucket" "main" {
     }
   }
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = var.furyagent_bucket_name
+    }
 }

--- a/modules/s3-furyagent/user.tf
+++ b/modules/s3-furyagent/user.tf
@@ -5,12 +5,12 @@
  */
 
 resource "aws_iam_user" "main" {
-  name = "${var.cluster_name}-${var.environment}-furyagent-backup"
+  name = "${var.furyagent_bucket_name}-furyagent-backup"
   path = "/"
 }
 
 resource "aws_iam_policy_attachment" "main" {
-  name       = "${var.cluster_name}-${var.environment}-furyagent-backup"
+  name       = "${var.furyagent_bucket_name}-furyagent-backup"
   users      = [aws_iam_user.main.name]
   policy_arn = aws_iam_policy.main.arn
 }
@@ -21,7 +21,7 @@ resource "aws_iam_access_key" "main" {
 }
 
 resource "aws_iam_policy" "main" {
-  name = "${var.cluster_name}-${var.environment}-furyagent-backup"
+  name = "${var.furyagent_bucket_name}-furyagent-backup"
 
   policy = <<EOF
 {
@@ -48,7 +48,7 @@ EOF
 }
 
 resource "aws_iam_policy" "join" {
-  name = "${var.cluster_name}-${var.environment}-furyagent-join"
+  name = "${var.furyagent_bucket_name}-furyagent-join"
 
   policy = <<EOF
 {

--- a/modules/s3-furyagent/user.tf
+++ b/modules/s3-furyagent/user.tf
@@ -7,6 +7,7 @@
 resource "aws_iam_user" "main" {
   name = "${var.furyagent_bucket_name}-furyagent-backup"
   path = "/"
+  tags = var.tags
 }
 
 resource "aws_iam_policy_attachment" "main" {


### PR DESCRIPTION
This PR simplifies the interface of the module.
Now only the `furyagent_bucket_name` is required as input, and new optional variable `tags` is added to replace the removed variables.

PR Review:
- removes the input variables: `cluster_name`, `environment` that were mainly used to add fixed tags. Now tags can be consistent with other resources. 
- uses the `furyagent_bucket_name` to name IAM policy and users (bucket name is already unique by default). 
- removes the input variables: `aws_region` which is now taken from the bucket region. This is consistent as the bucket is created in the AWS provider current region.